### PR TITLE
Allow specifying GraphQL API tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ module.exports = {
         // or `overlayDrafts` is set to true
         token: '<tokenWithReadRights>',
         overlayDrafts: false,
-        watchMode: false
+        watchMode: false,
+
+        // If the Sanity GraphQL API was deployed using `--tag <name>`,
+        // use `graphqlTag` to specify the tag name. Defaults to `default`.
+        graphqlTag: 'default'
       }
     }
   ]
@@ -51,14 +55,15 @@ module.exports = {
 
 ## Options
 
-| Options       | Type    | Default  | Description                                                                                                                                                                  |
-| ------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| projectId     | string  |          | **[required]** Your Sanity project's ID                                                                                                                                      |
-| dataset       | string  |          | **[required]** The dataset to fetch from                                                                                                                                     |
-| token         | string  |          | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                               |
-| overlayDrafts | boolean | `false`  | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                                    |
-| watchMode     | boolean | `false`  | Set to `true` to keep a listener open and update with the latest changes in realtime. If you enable `overlayDrafts`, changes will be reflected almost down to each keypress. |
-| typeName      | string  | `Sanity` | Prefix for schema types and queries.                                                                                                                                         |
+| Options       | Type    | Default   | Description                                                                                                                                                                  |
+| ------------- | ------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectId     | string  |           | **[required]** Your Sanity project's ID                                                                                                                                      |
+| dataset       | string  |           | **[required]** The dataset to fetch from                                                                                                                                     |
+| token         | string  |           | Authentication token for fetching data from private datasets, or when using `overlayDrafts` [Learn more](https://www.sanity.io/docs/http-auth)                               |
+| graphqlTag    | string  | `default` | If the Sanity GraphQL API was deployed using `--tag <name>`, use this to specify the tag name.                                                                               |
+| overlayDrafts | boolean | `false`   | Set to `true` in order for drafts to replace their published version. By default, drafts will be skipped.                                                                    |
+| watchMode     | boolean | `false`   | Set to `true` to keep a listener open and update with the latest changes in realtime. If you enable `overlayDrafts`, changes will be reflected almost down to each keypress. |
+| typeName      | string  | `Sanity`  | Prefix for schema types and queries.                                                                                                                                         |
 
 ## Preview of unpublished content
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class SanitySource {
       projectId: '',
       dataset: '',
       token: '',
+      graphqlTag: 'default',
       overlayDrafts: false,
       watchMode: false
     }
@@ -31,7 +32,7 @@ class SanitySource {
   constructor(api, options) {
     this.options = options
 
-    const {projectId, dataset, token, overlayDrafts} = options
+    const {projectId, dataset, token, overlayDrafts, graphqlTag} = options
 
     if (overlayDrafts && !token) {
       console.warn('[sanity] `overlayDrafts` set to true, but no `token` specified!')
@@ -52,7 +53,7 @@ class SanitySource {
     })
 
     api.loadSource(async store => {
-      const remoteSchema = await getRemoteGraphQLSchema(this.client)
+      const remoteSchema = await getRemoteGraphQLSchema(this.client, graphqlTag)
       await this.declareContentTypes(store, remoteSchema)
       await this.getDocuments(store)
     })

--- a/src/remoteGraphQLSchema.js
+++ b/src/remoteGraphQLSchema.js
@@ -1,14 +1,13 @@
 const {parse} = require('graphql')
 
-module.exports = async client => {
-  const graphqlApi = 'default'
+module.exports = async (client, graphqlTag) => {
   const config = client.config()
   const {dataset} = config
 
   let api
   try {
     api = await client.request({
-      url: `/apis/graphql/${dataset}/${graphqlApi}`,
+      url: `/apis/graphql/${dataset}/${graphqlTag}`,
       headers: {
         Accept: 'application/graphql'
       }


### PR DESCRIPTION
This adds support for specifying the GraphQL API tag name to use for introspecting the schema.