### PR TITLE
Add apiVersion field in options config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ module.exports = {
         overlayDrafts: false,
         // Only enable real-time changes in development
         watchMode: process.env.NODE_ENV === "development",
+        // API Version has to be set to today's date for the latest features.
+        // See: https://sanity.io/help/js-client-api-version
+        apiVersion: '2021-10-14',
 
         // If the Sanity GraphQL API was deployed using `--tag <name>`,
         // use `graphqlTag` to specify the tag name. Defaults to `default`.

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class SanitySource {
   constructor(api, options) {
     this.options = options
 
-    const {projectId, dataset, token, overlayDrafts, graphqlTag} = options
+    const {projectId, dataset, token, overlayDrafts, graphqlTag, apiVersion} = options
 
     if (overlayDrafts && !token) {
       console.warn('[sanity] `overlayDrafts` set to true, but no `token` specified!')
@@ -45,7 +45,7 @@ class SanitySource {
 
     this.uidPrefix = sha1([projectId, dataset, token].join('-'))
     this.client = sanityClient({
-      apiVersion: '1',
+      apiVersion,
       useCdn: false,
       projectId,
       dataset,


### PR DESCRIPTION
I have added an apiVersion field to the config. It's optional.
The current hardcoded "v1" is deprecated so passing in the version is preferred.

Not sure whether the order of the fields in the `sanityClient` constructor is correct, would like a review of that for sure.